### PR TITLE
Handle degenerate orthogonal vector for hub creation

### DIFF
--- a/createUamHubs.py
+++ b/createUamHubs.py
@@ -36,10 +36,15 @@ def get_orthogonal_points(centre: (float, float), point: (float, float), distanc
     dx = point[0] - centre[0]
     dy = point[1] - centre[1]
 
-    # normalize the direction vector
-    length = math.sqrt(dx ** 2 + dy ** 2)
-    dx /= length
-    dy /= length
+    # normalize the direction vector. If the centre and the point are identical, fall back to a
+    # default orientation to avoid dividing by zero (this happens when only a single hub
+    # coordinate is provided).
+    length = math.hypot(dx, dy)
+    if length == 0:
+        dx, dy = 1.0, 0.0
+    else:
+        dx /= length
+        dy /= length
 
     # calculate the orthogonal vector
     orthogonal_dx = -dy

--- a/tests/test_create_uam_hubs.py
+++ b/tests/test_create_uam_hubs.py
@@ -1,0 +1,39 @@
+import math
+import pathlib
+import sys
+
+
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+
+from createUamHubs import get_orthogonal_points
+
+
+def test_get_orthogonal_points_handles_single_coordinate():
+    centre = (0.0, 0.0)
+    point = (0.0, 0.0)
+    distance = 10.0
+
+    first, second = get_orthogonal_points(centre, point, distance)
+
+    # With a single point the orthogonal points should be placed directly above and below the
+    # original coordinate at the requested distance.
+    assert math.isclose(first[0], point[0])
+    assert math.isclose(second[0], point[0])
+    assert math.isclose(first[1], point[1] - distance)
+    assert math.isclose(second[1], point[1] + distance)
+
+
+def test_get_orthogonal_points_distance_preserved():
+    centre = (1.0, 1.0)
+    point = (3.0, 1.0)
+    distance = 5.0
+
+    first, second = get_orthogonal_points(centre, point, distance)
+
+    # Both points should be exactly `distance` away from the original point.
+    assert math.isclose(math.dist(first, point), distance)
+    assert math.isclose(math.dist(second, point), distance)
+


### PR DESCRIPTION
## Summary
- avoid dividing by zero in `get_orthogonal_points` by falling back to a default orientation when the hub location equals the centre
- add regression tests for `get_orthogonal_points` to cover the degenerate single-coordinate scenario and distance preservation

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d0fbab01188332ad681358fc7b9336