### PR TITLE
Guard against empty coordinate lists

### DIFF
--- a/createUamHubs.py
+++ b/createUamHubs.py
@@ -23,6 +23,9 @@ def get_options():
 
 
 def get_centre(coordinates: list[(float, float)]) -> (float, float):
+    if not coordinates:
+        raise ValueError("At least one coordinate is required to calculate the centre.")
+
     xs = [p[0] for p in coordinates]
     ys = [p[1] for p in coordinates]
     centre = (sum(xs) / len(coordinates), sum(ys) / len(coordinates))

--- a/tests/test_create_uam_hubs.py
+++ b/tests/test_create_uam_hubs.py
@@ -8,7 +8,9 @@ if str(ROOT) not in sys.path:
     sys.path.insert(0, str(ROOT))
 
 
-from createUamHubs import get_orthogonal_points
+import pytest
+
+from createUamHubs import get_centre, get_orthogonal_points
 
 
 def test_get_orthogonal_points_handles_single_coordinate():
@@ -36,4 +38,9 @@ def test_get_orthogonal_points_distance_preserved():
     # Both points should be exactly `distance` away from the original point.
     assert math.isclose(math.dist(first, point), distance)
     assert math.isclose(math.dist(second, point), distance)
+
+
+def test_get_centre_rejects_empty_coordinate_list():
+    with pytest.raises(ValueError):
+        get_centre([])
 


### PR DESCRIPTION
## Summary
- raise a clear ValueError when `get_centre` is called with no coordinates
- extend the unit tests to cover the new error handling

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68d2f71138d88332bbc97cf8623fc2a4